### PR TITLE
Fixed 'Create New Webhook' button

### DIFF
--- a/web/src/components/Navigation/Navigation.tsx
+++ b/web/src/components/Navigation/Navigation.tsx
@@ -34,7 +34,7 @@ const Navigation: React.FC<NavProps> = ({ buttonLabel, buttonTo }) => {
               <a href="#" onClick={logOut}>
               <ListItem>Logout</ListItem>
             </a>
-            <Link to={buttonTo}>
+            <Link to={routes[`${buttonTo}`]()}>
               <ListItem styles="bg-emerald-800 text-white">+ {buttonLabel}</ListItem>
             </Link>
           </>

--- a/web/src/layouts/DefaultLayout/DefaultLayout.tsx
+++ b/web/src/layouts/DefaultLayout/DefaultLayout.tsx
@@ -10,7 +10,7 @@ const DefaultLayout = ({ children }: DefaultLayoutProps) => {
   return (
     <>
       <Header />
-      <Navigation />
+      <Navigation buttonLabel="" buttonTo="home" />
       <main className='flex items-center justify-center px-5'>{children}</main>
     </>
   )


### PR DESCRIPTION
Since `Routes.tsx` only passes button props in case of `ScaffoldLayout` only, the `DefaultLayout.tsx` has been modified to accomodate for the home and about page too.

Fixes #29 and #27 